### PR TITLE
Clean up descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A curated list of awesome things related to <a href='https://github.com/vitejs/v
 - [vite-plugin-components](https://github.com/antfu/vite-plugin-components) - On-demand components auto-importing.
 - [vite-transform-globby-import](https://github.com/luxueyan/vite-transform-globby-import) - Simple globby-import transform.
 - [vite-plugin-purge-icons](https://github.com/antfu/purge-icons/tree/main/packages/vite-plugin-purge-icons) - Bundles icons on demand by PurgeIcons.
-- [@baleada/vite-serve-as-vue](https://baleada.netlify.app/docs/vite-serve-as-vue) - Dev server plugin to serve any files as a hot-reloadable Vue component.
+- [@baleada/vite-serve-as-vue](https://baleada.netlify.app/docs/vite-serve-as-vue) - Dev server plugin to serve any files as hot-reloadable Vue components.
 - [@baleada/vite-serve-virtual](https://baleada.netlify.app/docs/vite-serve-virtual) - Dev server plugin to serve virtual files of any type.
 
 ### Frameworks other than Vue 3


### PR DESCRIPTION
Removed descriptions about `for Vite` if it's not very necessary.