### PR TITLE
feat: add vite-electron-quick template

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A curated list of awesome things related to <a href='https://github.com/vitejs/v
 - [Vitesse](https://github.com/antfu/vitesse) - Opinionated Vite starter template.
 - [vite-vue3-tailwind-starter](https://github.com/web2033/vite-vue3-tailwind-starter) - Starter template with Vue 3, Vue Router and Tailwind CSS.
 - [vite-ts-tailwind-starter](https://github.com/Uninen/vite-ts-tailwind-starter) - Starter template w/ TypeScript, Tailwind CSS, Cypress.io e2e tests + CI.
-- [vite-electron-quick](https://github.com/MangoTsing/vite-electron-quick) - Starter template with Vue 3, TypeScript and Electron 11.x.
+- [vite-electron-quick](https://github.com/MangoTsing/vite-electron-quick) - Starter template with Vue 3, TypeScript and Electron 11.
 
 <!--
 #### React

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A curated list of awesome things related to <a href='https://github.com/vitejs/v
 - [Vitesse](https://github.com/antfu/vitesse) - Opinionated Vite starter template.
 - [vite-vue3-tailwind-starter](https://github.com/web2033/vite-vue3-tailwind-starter) - Starter template with Vue 3, Vue Router and Tailwind CSS.
 - [vite-ts-tailwind-starter](https://github.com/Uninen/vite-ts-tailwind-starter) - Starter template w/ TypeScript, Tailwind CSS, Cypress.io e2e tests + CI.
+- [vite-electron-quick](https://github.com/MangoTsing/vite-electron-quick) - Starter template with Vue 3, TypeScript and Electron 11.x.
 
 <!--
 #### React


### PR DESCRIPTION
add new template.
- [vite-electron-quick](https://github.com/MangoTsing/vite-electron-quick) - Starter template with Vue 3, TypeScript and Electron 11.x.