### PR TITLE
feat: official rollup plugins compat update

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,16 +215,31 @@ A curated list of awesome things related to <a href='https://github.com/vitejs/v
 - [@rollup/plugin-dynamic-import-vars](https://github.com/rollup/plugins/blob/master/packages/dynamic-import-vars) - Resolving dynamic imports that contain variables.
 - [@rollup/plugin-json](https://github.com/rollup/plugins/blob/master/packages/json) - Convert `.json` files to ES6 modules.
 
+#### Covered by default in Vite
+
+- [@rollup/plugin-babel](https://github.com/rollup/plugins/tree/master/packages/babel) - Compile your files with Babel.
+- [@rollup/plugin-buble](https://github.com/rollup/plugins/tree/master/packages/buble) - Compile ES2015 with buble.
+- [@rollup/plugin-data-uri](https://github.com/rollup/plugins/tree/master/packages/data-uri) - Import modules from Data URIs.
+- [@rollup/plugin-html](https://github.com/rollup/plugins/tree/master/packages/html) - Create HTML files to serve Rollup bundles.
+- [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve) - Locate and bundle third-party dependencies in node_modules.
+- [@rollup/plugin-sucrase](https://github.com/rollup/plugins/tree/master/packages/sucrase) - Compile TypeScript, Flow, JSX, etc with Sucrase.
+- [@rollup/plugin-typescript](https://github.com/rollup/plugins/tree/master/packages/typescript) - Integration between Rollup and Typescript.
+- [@rollup/plugin-wasm](https://github.com/rollup/plugins/tree/master/packages/wasm) - Import WebAssembly code with Rollup.
+- [@rollup/plugin-url](https://github.com/rollup/plugins/tree/master/packages/url) - Import files as data-URIs or ES Modules.
+
 #### Compatible with Vite
 
 - [@rollup/plugin-beep](https://github.com/rollup/plugins/tree/master/packages/beep) - System beeps on errors and warnings.
 - [@rollup/plugin-dsv](https://github.com/rollup/plugins/blob/master/packages/dsv) - Convert `.csv` and `.tsv` files into JavaScript modules with d3-dsv.
+- [@rollup/plugin-eslint](https://github.com/rollup/plugins/blob/master/packages/eslint) - Verify entry point and all imported files with ESLint.
 - [@rollup/plugin-graphql](https://github.com/rollup/plugins/blob/master/packages/graphql) - Convert .gql/.graphql files to ES6 modules.
 - [@rollup/plugin-image](https://github.com/rollup/plugins/blob/master/packages/image) - Import JPG, PNG, GIF, SVG, and WebP files (needs enforce: 'pre').
 - [@rollup/plugin-inject](https://github.com/rollup/plugins/blob/master/packages/inject) - Scan modules for global variables and injects import statements where necessary.
+- [@rollup/plugin-legacy](https://github.com/rollup/plugins/tree/master/packages/legacy) - Add export declarations to legacy non-module scripts.
 - [@rollup/plugin-replace](https://github.com/rollup/plugins/tree/master/packages/replace) - Replace strings in files while bundling.
-- [@rollup/plugin-yaml](https://github.com/rollup/plugins/blob/master/packages/yaml) - Convert YAML files to ES6 modules.
+- [@rollup/plugin-strip](https://github.com/rollup/plugins/tree/master/packages/strip) - Remove debugger statements and functions like assert.equal and console.log from your code.
 - [@rollup/plugin-virtual](https://github.com/rollup/plugins/blob/master/packages/virtual) - A Rollup plugin which loads virtual modules from memory.
+- [@rollup/plugin-yaml](https://github.com/rollup/plugins/blob/master/packages/yaml) - Convert YAML files to ES6 modules.
 
 #### Community
 


### PR DESCRIPTION
### `General`

> ✏️ Mark the necessary items without changing the structure of the PR template.

- [x] Pull request template structure not broken

### `Type`

> ℹ️  What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [ ] Fix
- [x] Feature 

### `Checklist`

> ℹ️  Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](https://github.com/vuejs/awesome-vue/blob/master/.github/contributing.md).

> 👉  _Put an `x` in the boxes that apply._

- [x] Title as described.
- [x] Make sure you put things in the right category!
- [x] Always add your items to the end of a list.
- [x] Your plugin/tool is working with Vite 2.0 and onward.

@antfu I can merge this PR, but wanted to ask your opinion about including the **Covered by default in Vite** section. 
If we do not include them, I think we are giving the impression that these plugins are not compatible. But including them as is could be a bit confusing also, because users needs to dig in the Vite docs to understand how they are actually covered. In [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev/) I included a link to the right section in Vite docs (we could add the same here), and for some of them I will start including extra info to explain what covered means (for example, for babel, what is covered is support for old browsers, and using it for experimental features is not recommended).

So, options :)

1. we simply list them as I did in this PR
2. we add an extra link to Vite docs for each of them
3. we remove this section, and add a note that other plugins not included are covered

What do you think?