### PR TITLE
chore: plugin conventions in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,11 +12,12 @@
 
 - [ ] The plugin/tool is working with **Vite 2.0 and onward**.
 - [ ] The project is Open Source.
+- [ ] The project follows the [Vite Plugins Conventions](https://vitejs.dev/guide/api-plugin.html#conventions).
 - [ ] The repo should be at least 30 days old.
 - [ ] The documentation is in English.
 - [ ] The project is active and maintained.
 - [ ] The project accepts contributions.
-- [ ] Not a commercial product
+- [ ] Not a commercial product.
 
 ### Apps/Websites
 


### PR DESCRIPTION
@antfu add a step in the Plugin/Tools checklist about following the [Vite Plugin Conventions](https://vitejs.dev/guide/api-plugin.html#conventions). In case other conventions are added in the future, I think it is better to just point to that section to avoid the need to keep the template in sync. If you would prefer a different wording, or explicitly naming the conventions, please go ahead 👍🏼 
