### PR TITLE
update `@brillout/vite-plugin-mdx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 #### Loaders
 
 - [vite-plugin-svgr](https://github.com/pd4d10/vite-plugin-svgr) - Transform SVGs into React components.
-- [@brillout/vite-plugin-mdx](https://github.com/brillout/vite-plugin-mdx) - Use MDX for your Vite app, with support for MDX v1, MDX v2, HMR, and SSR.
+- [vite-plugin-mdx](https://github.com/brillout/vite-plugin-mdx) - Use MDX for your Vite app, with support for MDX v1, MDX v2, HMR, and SSR.
 
 #### Framework
 


### PR DESCRIPTION
https://github.com/brillout/vite-plugin-mdx now lives at https://www.npmjs.com/package/vite-plugin-mdx