### PR TITLE
docs: refactor ssr

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ SSR frameworks are listed at [SSR - Frameworks](#frameworks).
 
 #### Framework
 
-> :warning: SSR frameworks are listed at [SSR - Frameworks](#frameworks).
+> 💡 SSR frameworks are listed at [SSR - Frameworks](#ssr).
 
 - [vite-plugin-react-pages](https://github.com/vitejs/vite-plugin-react-pages) - A Vite framework for building React app.
 - [@vitjs/vit](https://github.com/vitjs/vit) - React application framework inspired by UmiJS.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Use the "Table on Contents" menu on the top-left corner to explore the list.
 #### Svelte
 
 - [sttv](https://github.com/srmullen/sttv) - Svelte, TailwindCSS, TypeScript.
+- [svelte-vite-ssr](https://github.com/jiangfengming/svelte-vite-ssr) - Svelte with SSR support.
 
 ## Plugins
 
@@ -171,6 +172,10 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 - ![v3] [vite-plugin-vuedoc](https://github.com/JasKang/vite-plugin-vuedoc) - Markdown Code block as Vue Preview components.
 - ![v3] [vite-svg-loader](https://github.com/jpkleemans/vite-svg-loader) - Load SVG files as Vue components.
 
+#### SSR
+
+SSR frameworks are listed at [SSR - Frameworks](#frameworks).
+
 #### SSG
 
 - ![v3] [vite-ssg](https://github.com/antfu/vite-ssg) - Server-side generation.
@@ -212,6 +217,8 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 - [vite-plugin-twstyled](https://github.com/twstyled/twstyled/tree/main/packages/vite-plugin-twstyled) - Plugin to compile Tailwind CSS with JSX and CSS-in-JS support.
 
 #### Framework
+
+> :warning: SSR frameworks are listed at [SSR - Frameworks](#frameworks).
 
 - [vite-plugin-react-pages](https://github.com/vitejs/vite-plugin-react-pages) - A Vite framework for building React app.
 - [@vitjs/vit](https://github.com/vitjs/vit) - React application framework inspired by UmiJS.
@@ -284,10 +291,6 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 ### Frameworks
 
 - [vitedge](https://github.com/frandiox/vitedge) ![react] ![vue3] - Edge-side rendering with fullstack utilities.
-
-### Boilerplates
-
-- [svelte-vite-ssr](https://github.com/jiangfengming/svelte-vite-ssr) ![svelte] - Svelte with SSR support.
 
 <!--lint enable awesome-list-item-->
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Use the "Table on Contents" menu on the top-left corner to explore the list.
 #### Svelte
 
 - [sttv](https://github.com/srmullen/sttv) - Svelte, TailwindCSS, TypeScript.
-- [svelte-vite-ssr](https://github.com/jiangfengming/svelte-vite-ssr) - Svelte with SSR support.
 
 ## Plugins
 
@@ -120,10 +119,6 @@ Use the "Table on Contents" menu on the top-left corner to explore the list.
 - [vite-plugin-handlebars](https://github.com/alexlafroscia/vite-plugin-handlebars) - Process HTML files with Handlebars.
 - [vite-plugin-html-config](https://github.com/ahwgs/vite-plugin-html-config) - HTML tag configuration, such as script link style meta favicon and more.
 - [vite-plugin-html-template](https://github.com/IndexXuan/vite-plugin-html-template) - HTML template for vite app, like html-webpack-plugin for webpack.
-
-#### SSR
-
-- [vite-plugin-ssr](https://github.com/brillout/vite-plugin-ssr) - Like Nuxt/Next.js but with a simpler design that works with any view framework.
 
 #### Helpers
 
@@ -176,11 +171,9 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 - ![v3] [vite-plugin-vuedoc](https://github.com/JasKang/vite-plugin-vuedoc) - Markdown Code block as Vue Preview components.
 - ![v3] [vite-svg-loader](https://github.com/jpkleemans/vite-svg-loader) - Load SVG files as Vue components.
 
-#### SSR / SSG
+#### SSG
 
 - ![v3] [vite-ssg](https://github.com/antfu/vite-ssg) - Server-side generation.
-- ![v3] [vite-ssr](https://github.com/frandiox/vite-ssr) - Server-side rendering.
-- ![v3] [vitedge](https://github.com/frandiox/vitedge) - Edge-side rendering with fullstack utilities.
 
 #### Ecosystem
 
@@ -273,6 +266,27 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 #### Community
 
 - Check the [Awesome Rollup list](https://github.com/rollup/awesome) for community maintained rollup plugins, and refer to the Vite docs section about [rollup plugin compatibility](https://vitejs.dev/guide/api-plugin.html#rollup-plugin-compatiblity).
+
+## SSR
+
+[react]: https://img.shields.io/badge/-React-61dafb
+[vue2]: https://img.shields.io/badge/-Vue%20v2-41b883
+[vue3]: https://img.shields.io/badge/-Vue%20v3-41b883
+[svelte]: https://img.shields.io/badge/-Svelte-ff3e00
+
+<!--lint disable awesome-list-item-->
+
+### Libraries
+
+- [vite-ssr](https://github.com/frandiox/vite-ssr) ![react] ![vue3] - Server-side rendering.
+- [vite-plugin-ssr](https://github.com/brillout/vite-plugin-ssr) ![react] ![vue3] ![vue2] ![svelte] - Like Nuxt/Next.js but as a do-one-thing-do-it-well plugin.
+
+### Frameworks & Boilerplates
+
+- [vitedge](https://github.com/frandiox/vitedge) ![react] ![vue3] - Edge-side rendering with fullstack utilities.
+- [svelte-vite-ssr](https://github.com/jiangfengming/svelte-vite-ssr) ![svelte] - Svelte with SSR support.
+
+<!--lint enable awesome-list-item-->
 
 ## Integrations with Backends
 

--- a/README.md
+++ b/README.md
@@ -281,9 +281,12 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 - [vite-ssr](https://github.com/frandiox/vite-ssr) ![react] ![vue3] - Server-side rendering.
 - [vite-plugin-ssr](https://github.com/brillout/vite-plugin-ssr) ![react] ![vue3] ![vue2] ![svelte] - Like Nuxt/Next.js but as a do-one-thing-do-it-well plugin.
 
-### Frameworks & Boilerplates
+### Frameworks
 
 - [vitedge](https://github.com/frandiox/vitedge) ![react] ![vue3] - Edge-side rendering with fullstack utilities.
+
+### Boilerplates
+
 - [svelte-vite-ssr](https://github.com/jiangfengming/svelte-vite-ssr) ![svelte] - Svelte with SSR support.
 
 <!--lint enable awesome-list-item-->

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 
 #### SSR
 
-SSR frameworks are listed at [SSR - Frameworks](#frameworks).
+SSR frameworks are listed at [SSR - Frameworks](#ssr).
 
 #### SSG
 


### PR DESCRIPTION
Rendered version: https://github.com/brillout/awesome-vite/tree/refactor-ssr#ssr.

Follow up of https://discord.com/channels/804011606160703521/804061937029218334/844266963244941348.

The plan is to add a link to the SSR section at https://vitejs.dev/guide/ssr.

@frandiox How about we change the description of `vite-ssr`? Maybe `SSR with bring your own router`?

cc @patak-js