### PR TITLE
Add app and website react-device-frameset

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,4 +356,4 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 - [macOS Web](https://github.com/PuruVJ/macos-web/) - macOS Desktop experience for Web.
 - [vue3-realworld-example-app](https://github.com/mutoe/vue3-realworld-example-app) - Realworld app implementation using Vue 3 + TypeScript + Composition API.
 - [vue3-ssr-realworld-example-app](https://github.com/levchak0910/vue3-ssr-realworld-example-app) - Realworld app implementation using Vue 3 with SSR.
-- [react-device-frameset](https://github.com/zheeeng/react-device-frameset) - This is yet another device frameset component for React. You could check the [online demo](https://react-device-frameset.zheeeng.me/).
+- [react-device-frameset](https://github.com/zheeeng/react-device-frameset) - This is yet another device frameset component for React.

--- a/README.md
+++ b/README.md
@@ -356,3 +356,4 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 - [macOS Web](https://github.com/PuruVJ/macos-web/) - macOS Desktop experience for Web.
 - [vue3-realworld-example-app](https://github.com/mutoe/vue3-realworld-example-app) - Realworld app implementation using Vue 3 + TypeScript + Composition API.
 - [vue3-ssr-realworld-example-app](https://github.com/levchak0910/vue3-ssr-realworld-example-app) - Realworld app implementation using Vue 3 with SSR.
+- [react-device-frameset](https://github.com/zheeeng/react-device-frameset) - This is yet another device frameset component for React. You could check the [online demo](https://react-device-frameset.zheeeng.me/).


### PR DESCRIPTION
Add app and website `react-device-frameset` which is built by `Vite`, and its demo site is powered by `vite-plugin-react-pages`.

> Please make sure all the requirements are satisfied, otherwise the PR could be closed without further notice.

## Checklist

- [x] Title as described.
- [x] Make sure you put things in the right category.
- [x] The description of your item should be a sentence with less than 24 words.
- [x] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [x] Always add your items to the end of a list.

### Plugins/Tools

<!-- Ignore if you are not contributing to Plugins/Tools -->

- [x] The plugin/tool is working with **Vite 2.0 and onward**.
- [x] The project is Open Source.
- [x] The project follows the [Vite Plugins Conventions](https://vitejs.dev/guide/api-plugin.html#conventions).
- [x] The repo should be at least 30 days old.
- [x] The documentation is in English.
- [x] The project is active and maintained.
- [x] The project accepts contributions.
- [x] Not a commercial product.

### Starter Templates

<!-- Ignore if you are not contributing to Starter Templates -->

- [ ] The starter template is working with **Vite 2.0 and onward**.
- [ ] The documentation is in English.
- [ ] The starter template most provide enough instructions / documentation about how to start up and what's is included.
- [ ] A screenshot or a live demo should be included.
- [ ] The repo should be at least 30 days old.
- [ ] Should be differentiable from the existing starter templates. 

### Apps/Websites

<!-- Ignore if you are not contributing to Apps/Websites -->

- [ ] The website is available without errors and load in a reasonable amount of time.
- [ ] The website must be Open Source and showing it's using Vite intensively.
- [ ] The website is original and not too simple. For that reason, blogs and simple landing pages are rejected.
