### PR TITLE
Add @nabla/vite-plugin-eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-plugin-linter](https://bitbucket.org/unimorphic/vite-plugin-linter) - Extensible linter framework that shows the linting output in the Vite output and the browser console, includes ESLint & TypeScript ootb.
 - [vite-plugin-checker](https://github.com/fi3ework/vite-plugin-checker) - Fast run checkers (TypeScript/VLS/vue-tsc, etc.) in worker threads with overlay and terminal hint.
 - [vite-plugin-stimulus-hmr](https://github.com/ElMassimo/vite-plugin-stimulus-hmr) - Integration with Stimulus enabling HMR.
+- [@nabla/vite-plugin-eslint](https://github.com/nabla/vite-plugin-eslint) - Runs ESLint asynchronously in a worker to keep HMR fast.
 
 #### Loaders
 


### PR DESCRIPTION
## Checklist

- [x] The plugin/tool is working with **Vite 2.0 and onward**.
- [x] The project is Open Source.
- [ ] The project follows the [Vite Plugins Conventions](https://vitejs.dev/guide/api-plugin.html#conventions).
- [x] The repo should be at least 30 days old.
- [x] The documentation is in English.
- [x] The project is active and maintained.
- [x] The project accepts contributions.
- [x] Not a commercial product.

There is two missing points on the `Vite Plugins Conventions`:
- Add `vite-plugin` keyword. I will publish a minor version to add it if it's only thing blocking
- A reason why it's not a rollup plugin: Is keeping the possibility to use future vite only API's and never tested the project outside of Vite a valid reason?