### PR TITLE
docs: added a plugin vite-plugin-external

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-plugin-restart](https://github.com/antfu/vite-plugin-restart) - Restart the Vite server on file changes.
 - [vite-plugin-full-reload](https://github.com/ElMassimo/vite-plugin-full-reload) - Reload the browser on file changes.
 - [vite-plugin-tips](https://github.com/yingpengsha/vite-plugin-tips) - Provide better development server status tips on the page.
+- [vite-plugin-external](https://github.com/fengxinming/vite-plugins/tree/main/packages/vite-plugin-external) - Better to define externals in vite2. It not only work on our source code, but also work on pre-bundling dependencies well.
 
 #### Testing
 


### PR DESCRIPTION
The plugin `vite-plugin-externals` could not exclude externals of pre-bundling dependencies, then I found a new way to solve this problem.

> Please make sure all the requirements are satisfied, otherwise the PR could be closed without further notice.

## Checklist

- [ ] Title as described.
- [ ] Make sure you put things in the right category.
- [ ] The description of your item should be a sentence with less than 24 words.
- [ ] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [ ] Always add your items to the end of a list.

### Plugins/Tools

<!-- Ignore if you are not contributing to Plugins/Tools -->

- [ ] The plugin/tool is working with **Vite 2.0 and onward**.
- [ ] The project is Open Source.
- [ ] The project follows the [Vite Plugins Conventions](https://vitejs.dev/guide/api-plugin.html#conventions).
- [ ] The repo should be at least 30 days old.
- [ ] The documentation is in English.
- [ ] The project is active and maintained.
- [ ] The project accepts contributions.
- [ ] Not a commercial product.

### Starter Templates

<!-- Ignore if you are not contributing to Starter Templates -->

- [ ] The starter template is working with **Vite 2.0 and onward**.
- [ ] The documentation is in English.
- [ ] The starter template most provide enough instructions / documentation about how to start up and what's is included.
- [ ] A screenshot or a live demo should be included.
- [ ] The repo should be at least 30 days old.
- [ ] Should be differentiable from the existing starter templates. 

### Apps/Websites

<!-- Ignore if you are not contributing to Apps/Websites -->

- [ ] The website is available without errors and load in a reasonable amount of time.
- [ ] The website must be Open Source and showing it's using Vite intensively.
- [ ] The website is original and not too simple. For that reason, blogs and simple landing pages are rejected.
