### PR TITLE
Add `vite-plugin-tauri`

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-plugin-stimulus-hmr](https://github.com/ElMassimo/vite-plugin-stimulus-hmr) - Integration with Stimulus enabling HMR.
 - [@nabla/vite-plugin-eslint](https://github.com/nabla/vite-plugin-eslint) - Runs ESLint asynchronously in a worker to keep HMR fast.
 - [vite-plugin-relay](https://github.com/oscartbeaumont/vite-plugin-relay) - Allows for the usage of [Relay](https://relay.dev).
+- [vite-plugin-tauri](https://github.com/amrbashir/vite-plugin-tauri) - Integrate Tauri in a Vite project to build cross-platform apps.
 
 #### Loaders
 


### PR DESCRIPTION
> Please make sure all the requirements are satisfied, otherwise the PR could be closed without further notice.

## Checklist

- [X] Title as described.
- [X] Make sure you put things in the right category.
- [X] The description of your item should be a sentence with less than 24 words.
- [X] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [X] Always add your items to the end of a list.

### Plugins/Tools

<!-- Ignore if you are not contributing to Plugins/Tools -->

- [X] The plugin/tool is working with **Vite 2.x and onward**.
- [X] The project is Open Source.
- [X] The project follows the [Vite Plugins Conventions](https://vitejs.dev/guide/api-plugin.html#conventions).
- [X] The plugin uses Vite specific hooks and can't be implemented as a [Compatible Rollup Plugin](https://vitejs.dev/guide/api-plugin.html#rollup-plugin-compatibility).
- [X] The repo should be at least 30 days old.
- [X] The documentation is in English.
- [X] The project is active and maintained (projects that inactive for longer that 6 months will be removed without further notice).
- [X] The project accepts contributions.
- [X] Not a commercial product.

### Starter Templates

<!-- Ignore if you are not contributing to Starter Templates -->

- [ ] The starter template is working with **Vite 2.x and onward**.
- [ ] The documentation is in English.
- [ ] The starter template most provide enough instructions / documentation about how to start up and what's is included.
- [ ] A screenshot or a live demo should be included.
- [ ] The repo should be at least 30 days old.
- [ ] Should be differentiable from the existing starter templates. 

### Apps/Websites

<!-- Ignore if you are not contributing to Apps/Websites -->

- [ ] The website is available without errors and load in a reasonable amount of time.
- [ ] The website must be Open Source and showing it's using Vite intensively.
- [ ] The website is original and not too simple. For that reason, blogs and simple landing pages are rejected.
