### PR TITLE
feat: add vite-plugin-require

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-plugin-plain-text](https://github.com/zheeeng/vite-plugin-plain-text) - A Vite plugin transforms the rule-matched file as plain text.
 - [vite-plugin-virtual-html-template](https://github.com/hex-ci/vite-plugin-virtual-html-template) - HTML template for vite app, support flexible virtual URL.
 - [vite-plugin-require-context](https://github.com/originjs/vite-plugins/tree/main/packages/vite-plugin-require-context) - A Vite plugin that supports `require.context` by code transforming.
-- [vite-plugin-require](https://github.com/wangzongming/vite-plugin-require) - A Vite plugin that supports `require` by code transforming.
 - [vite-remark-html](https://github.com/alloc/vite-remark-html) - Transform `.md` imports into HTML strings.
 - [vite-plugin-commonjs](https://github.com/originjs/vite-plugins/tree/main/packages/vite-plugin-commonjs) - Support commonJS to esm in vite.
 - [vite-plugin-vue2-suffix](https://github.com/williamyorkl/vite-plugin-vue2-suffix) - Compatible with no '.vue' suffix in vite (should be useful for those who transfer webpack to vite)
 - [vite-plugin-content](https://github.com/originjs/origin.js/tree/main/packages/vite-plugin-content) - Convert `yaml`, `xml`, `ini`, `toml`, `csv`, `plist` and `properties` files to ES6 modules.
+- [vite-plugin-require](https://github.com/wangzongming/vite-plugin-require) - A Vite plugin that supports `require` by code transforming.
 
 #### Helpers
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-plugin-plain-text](https://github.com/zheeeng/vite-plugin-plain-text) - A Vite plugin transforms the rule-matched file as plain text.
 - [vite-plugin-virtual-html-template](https://github.com/hex-ci/vite-plugin-virtual-html-template) - HTML template for vite app, support flexible virtual URL.
 - [vite-plugin-require-context](https://github.com/originjs/vite-plugins/tree/main/packages/vite-plugin-require-context) - A Vite plugin that supports `require.context` by code transforming.
+- [vite-plugin-require](https://github.com/wangzongming/vite-plugin-require) - A Vite plugin that supports `require` by code transforming.
 - [vite-remark-html](https://github.com/alloc/vite-remark-html) - Transform `.md` imports into HTML strings.
 - [vite-plugin-commonjs](https://github.com/originjs/vite-plugins/tree/main/packages/vite-plugin-commonjs) - Support commonJS to esm in vite.
 - [vite-plugin-vue2-suffix](https://github.com/williamyorkl/vite-plugin-vue2-suffix) - Compatible with no '.vue' suffix in vite (should be useful for those who transfer webpack to vite)


### PR DESCRIPTION
add vite-plugin-require

> Please make sure all the requirements are satisfied, otherwise the PR could be closed without further notice.

## Checklist

- [x] Title as described.
- [x] Make sure you put things in the right category.
- [x] The description of your item should be a sentence with less than 24 words.
- [x] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [x] Always add your items to the end of a list.

### Plugins/Tools

<!-- Ignore if you are not contributing to Plugins/Tools -->

- [ ] The plugin/tool is working with **Vite 2.x and onward**.
- [x] The project is Open Source.
- [x] The project follows the [Vite Plugins Conventions](https://vitejs.dev/guide/api-plugin.html#conventions).
- [ ] The plugin uses Vite specific hooks and can't be implemented as a [Compatible Rollup Plugin](https://vitejs.dev/guide/api-plugin.html#rollup-plugin-compatibility).
- [ ] The repo should be at least 30 days old.
- [x] The documentation is in English.
- [x] The project is active and maintained (projects that inactive for longer that 6 months will be removed without further notice).
- [x] The project accepts contributions.
- [x] Not a commercial product.

### Starter Templates

<!-- Ignore if you are not contributing to Starter Templates -->

- [ ] The starter template is working with **Vite 2.x and onward**.
- [ ] The documentation is in English.
- [ ] The starter template most provide enough instructions / documentation about how to start up and what's is included.
- [ ] A screenshot or a live demo should be included.
- [ ] The repo should be at least 30 days old.
- [ ] Should be differentiable from the existing starter templates. 

### Apps/Websites

<!-- Ignore if you are not contributing to Apps/Websites -->

- [ ] The website is available without errors and load in a reasonable amount of time.
- [ ] The website must be Open Source and showing it's using Vite intensively.
- [ ] The website is original and not too simple. For that reason, blogs and simple landing pages are rejected.
