### PR TITLE
feat: add vite-plugin-wasm-pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-plugin-relay](https://github.com/oscartbeaumont/vite-plugin-relay) - Allows for the usage of [Relay](https://relay.dev).
 - [vite-plugin-tauri](https://github.com/amrbashir/vite-plugin-tauri) - Integrate Tauri in a Vite project to build cross-platform apps.
 - [vite-plugin-federation](https://github.com/originjs/vite-plugin-federation) - Support Module Federation, Inspired by Webpack Module Federation feature.
+- [vite-plugin-wasm-pack](https://github.com/nshen/vite-plugin-wasm-pack) - Integration with rust [wasm-pack](https://github.com/rustwasm/wasm-pack), the simple way.
 
 #### Loaders
 


### PR DESCRIPTION
> Please make sure all the requirements are satisfied, otherwise the PR could be closed without further notice.

## Checklist

- [x] Title as described.
- [x] Make sure you put things in the right category.
- [x] The description of your item should be a sentence with less than 24 words.
- [x] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [x] Always add your items to the end of a list.

### Plugins/Tools

<!-- Ignore if you are not contributing to Plugins/Tools -->

- [x] The plugin/tool is working with **Vite 2.x and onward**.
- [x] The project is Open Source.
- [x] The project follows the [Vite Plugins Conventions](https://vitejs.dev/guide/api-plugin.html#conventions).
- [x] The plugin uses Vite specific hooks and can't be implemented as a [Compatible Rollup Plugin](https://vitejs.dev/guide/api-plugin.html#rollup-plugin-compatibility).
- [x] The repo should be at least 30 days old.
- [x] The documentation is in English.
- [x] The project is active and maintained (projects that inactive for longer that 6 months will be removed without further notice).
- [x] The project accepts contributions.
- [x] Not a commercial product.

### Starter Templates

<!-- Ignore if you are not contributing to Starter Templates -->

- [ ] The starter template is working with **Vite 2.x and onward**.
- [ ] The documentation is in English.
- [ ] The starter template most provide enough instructions / documentation about how to start up and what's is included.
- [ ] A screenshot or a live demo should be included.
- [ ] The repo should be at least 30 days old.
- [ ] Should be differentiable from the existing starter templates. 

### Apps/Websites

<!-- Ignore if you are not contributing to Apps/Websites -->

- [ ] The website is available without errors and load in a reasonable amount of time.
- [ ] The website must be Open Source and showing it's using Vite intensively.
- [ ] The website is original and not too simple. For that reason, blogs and simple landing pages are rejected.
