### PR TITLE
Add Vitalis template for vue 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vue3-template](https://github.com/lecoueyl/vue3-template) - Vite / Vue 3 / Tailwind CSS / vue-router / PNPM / ESlint Airbnb / Stylelint / GitHub pages actions / Netlify.
 - [Modern Vue](https://github.com/byoungd/modern-vue-template) - Modern Vue stack 2022.
 - [electron-vite-boilerplate](https://github.com/caoxiemeihao/electron-vite-boilerplate) - Support SerialPort, SQLite3 and node C/C++ addons.
+- [Vitalis](https://github.com/Edsonalencar/Vitalis-template) - Vite / Vue 3 / Vue Router 4 / TypeScript / Tailwind CSS / ESlint / Prettier.
 
 #### Vue 2
 


### PR DESCRIPTION
Adds the Vitalis model to the list of models for vue 3.

vitalis is a complete template that has Vue 3 - Vue Router 4 -
TypeScript - Tailwind CSS - ESlint - Prettier and a few more plugins for
Tailwind.
