### PR TITLE
Add vite-tailwind-stimulus-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-vanilla-tailwind-v3](https://github.com/huibizhang/template-vite-vanilla-tailwind-v3) - Starter template for Tailwindcss and prettier-plugin-tailwindcss build-in.
 - [vite-vanilla-ts-lib-starter](https://github.com/kbysiec/vite-vanilla-ts-lib-starter) - Starter for library (CJS, ESM, IIFE) with TypeScript, ESLint, Stylelint, Prettier, Jest, Husky + lint-staged.
 - [vite-tailwind-starter](https://github.com/kometolabs/vite-tailwind-starter) - NoJS Tailwind CSS starter template.
+- [vite-tailwind-stimulus-starter](https://github.com/jeremyfrank/vite-tailwind-stimulus-starter) - Starter template for Tailwind CSS and Stimulus controllers.
 
 #### Vue 3
 


### PR DESCRIPTION
Adds vite-tailwind-stimulus-starter to the _vanilla templates_ section, since Stimulus is much closer to vanilla js than it is to larger and more popular front-end frameworks. Could also be in a new section of its own or in the _other_ section. Looking for input on this. Thanks!

---

> Please make sure all the requirements are satisfied, otherwise the PR could be closed without further notice.

## Checklist

- [x] Title as described.
- [x] Make sure you put things in the right category.
- [x] The description of your item should be a sentence with less than 24 words.
- [x] Avoid using links and parentheses in description. 
- [x] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [x] Use proper case for terms (e.g. `GitHub`, `TypeScript`, `ESLint`, etc.)
- [x] When mentioning tools, omit versions whenever possible (e.g. use `TypeScript` instead of `TypeScript 4.x`, but keep `Vue 2` and `Vue 3` as they're incompatible).
- [ ] When mentioning package names, use quotes whenever possible.
- [x] Always add your items to the end of a list.

### Starter Templates

<!-- Ignore if you are not contributing to Starter Templates -->

- [x] The starter template is working with **Vite 2.x and onward**.
- [x] The documentation is in English.
- [x] The starter template most provide enough instructions / documentation about how to start up and what's is included.
- [x] A screenshot or a live demo should be included.
- [ ] The repo should be at least 30 days old.
- [x] Should be differentiable from the existing starter templates.