### PR TITLE
Add reference for Official Laravel Vite Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 
 ### Laravel
 
+- [Laravel Vite Plugin](https://github.com/laravel/vite-plugin) - Official Plugin for the Laravel framework.
 - [Laravel Vite](https://github.com/innocenzi/laravel-vite) - Integration for the Laravel framework.
 - [Laravel Livewire Plugin](https://github.com/def-studio/vite-livewire-plugin) - Enable hot reloading of Laravel Livewire components without losing state.
 


### PR DESCRIPTION
As it is written at the innocenzi/laravel-vite's readme, the project has low maintenance since Laravel built their own Vite integration. Then I believe it is razonable add the reference for the Official Laravel Vite Plugin here.