### PR TITLE
docs: add vite-plugin-gltf

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-plugin-glsl](https://github.com/UstymUkhman/vite-plugin-glsl) - Import shader file chunks.
 - [vite-plugin-svgo](https://github.com/r3dDoX/vite-plugin-svgo) - Load SVGs as plain string and transform with SVGO library.
 - [vite-plugin-remark-rehype](https://github.com/y-nk/vite-plugin-remark-rehype) - Loads and transform markdown files using the unified ecosystem.
+- [vite-plugin-gltf](https://github.com/nytimes/rd-bundler-3d-plugins) - Load, transform, optimize, and compress 3D files (.gltf, .glb).
 
 #### Bundling
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-plugin-glsl](https://github.com/UstymUkhman/vite-plugin-glsl) - Import shader file chunks.
 - [vite-plugin-svgo](https://github.com/r3dDoX/vite-plugin-svgo) - Load SVGs as plain string and transform with SVGO library.
 - [vite-plugin-remark-rehype](https://github.com/y-nk/vite-plugin-remark-rehype) - Loads and transform markdown files using the unified ecosystem.
-- [vite-plugin-gltf](https://github.com/nytimes/rd-bundler-3d-plugins) - Load, transform, optimize, and compress 3D files (.gltf, .glb).
+- [vite-plugin-gltf](https://github.com/nytimes/rd-bundler-3d-plugins) - Load, transform, optimize, and compress glTF 3D files.
 
 #### Bundling
 


### PR DESCRIPTION

- [vite-plugin-gltf](https://github.com/nytimes/rd-bundler-3d-plugins) - Load, transform, optimize, and compress glTF 3D files.

## Checklist

- [x] Title as described.
- [x] Make sure you put things in the right category.
- [x] The description of your item should be a sentence with less than 24 words.
- [x] Avoid using links and parentheses in description. 
- [x] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [x] Use proper case for terms (e.g. `GitHub`, `TypeScript`, `ESLint`, etc.)
- [x] When mentioning tools, omit versions whenever possible (e.g. use `TypeScript` instead of `TypeScript 4.x`, but keep `Vue 2` and `Vue 3` as they're incompatible).
- [x] When mentioning package names, use quotes whenever possible.
- [x] Always add your items to the end of a list.

### Plugins/Tools

<!-- Ignore if you are not contributing to Plugins/Tools -->

- [ ] ~~The plugin/tool is working with **Vite 2.x and onward**.~~
    - Tested with Vite 3.x+, not Vite 2.x.
- [x] The project is Open Source.
- [x] The project follows the [Vite Plugins Conventions](https://vitejs.dev/guide/api-plugin.html#conventions).
- [ ] ~~The plugin uses Vite-specific hooks and can't be implemented as a [Compatible Rollup Plugin](https://vitejs.dev/guide/api-plugin.html#rollup-plugin-compatibility).~~
    - We publish both vite- and rollup-prefixed plugins. They currently contain the same code, but I found it very [difficult](https://github.com/vitejs/vite/discussions/7515) to get the Rollup-compatible implementation working in Vite, and want to reserve the option of branching the implementations later.
- [x] The repo should be at least 30 days old.
- [x] The documentation is in English.
- [x] The project is active and maintained (inactive projects for longer 6 months will be removed without further notice).
- [x] The project accepts contributions.
- [x] Not a commercial product.

