### PR TITLE
docs: add vite-vanilla-ts-knockout template

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vit-singlefile-gzip](https://github.com/MillerRen/vite-singlefile-gzip.git) - Starter template for embedded.
 - [11st-Starter-Kit](https://github.com/stefanfrede/11st-starter-kit) - 11ty, powered by Vite with Tailwind CSS and Alpine.js.
 - [chrome-ext-template-preact-windi-vite](https://github.com/fell-lucas/chrome-ext-template-preact-windi-vite) - Preact, Windi CSS, TypeScript, Prettier, ESLint, GitHub Actions and Chrome Extension Manifest v3.
-- [vite-vanilla-ts-knockout](https://github.com/zeekrey/vite-vanilla-ts-knockout) - Starter template for Knockout.js with Vite and TypeScript.
+- [vite-vanilla-ts-knockout](https://github.com/zeekrey/vite-vanilla-ts-knockout) - Starter template for Knockout.js, TypeScript.
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vit-singlefile-gzip](https://github.com/MillerRen/vite-singlefile-gzip.git) - Starter template for embedded.
 - [11st-Starter-Kit](https://github.com/stefanfrede/11st-starter-kit) - 11ty, powered by Vite with Tailwind CSS and Alpine.js.
 - [chrome-ext-template-preact-windi-vite](https://github.com/fell-lucas/chrome-ext-template-preact-windi-vite) - Preact, Windi CSS, TypeScript, Prettier, ESLint, GitHub Actions and Chrome Extension Manifest v3.
+- [vite-vanilla-ts-knockout](https://github.com/zeekrey/vite-vanilla-ts-knockout) - Starter template for Knockout.js with Vite and TypeScript.
 
 ## Plugins
 


### PR DESCRIPTION
This PR adds a starter template for using Knockout.js with Vite and TypeScript.

## Motivation

Sure thing, if you are toying with the idea of using Vite, you're probably also using a modern frontend framework like React, Vue, Svelte... . And Knockout is anything but modern. **But:** I know there are still many legacy projects using Knockout (I mean, look at the weekly downloads at NPM). And perhaps these projects don't want to port the whole application to a new framework but still use a more modern bundler like Vite.

## Checklist

- [x] Title as described.
- [x] Make sure you put things in the right category.
- [x] The description of your item should be a sentence with less than 24 words.
- [x] Avoid using links and parentheses in description. 
- [x] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [x] Use proper case for terms (e.g. `GitHub`, `TypeScript`, `ESLint`, etc.)
- [x] When mentioning tools, omit versions whenever possible (e.g. use `TypeScript` instead of `TypeScript 4.x`, but keep `Vue 2` and `Vue 3` as they're incompatible).
- [x] When mentioning package names, use quotes whenever possible.
- [x] Always add your items to the end of a list.

### Starter Templates

- [x] The starter template is working with **Vite 2.x and onward**.
- [x] The documentation is in English.
- [x] The starter template must provide enough instructions / documentation about how to start up and what's included.
- [x] A screenshot or a live demo should be included.
- [ ] The repo should be at least 30 days old.
- [x] Should be differentiable from the existing starter templates. 
