### PR TITLE
docs: add vite-react-ts-tailwind template

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-mui-ts](https://github.com/emre-cil/vite-mui-ts) - React + TypeScript + Redux + Material UI + RRD + ESLint + Prettier.
 - [leo-react-app](https://github.com/Leo-Henrique/leo-react-app) - React + SASS | Template for React applications with SASS boilerplate for consistent interfaces.
 - [template-vite-react-ts-tailwind](https://github.com/RoyRao2333/template-vite-react-ts-tailwind) - React + TypeScript + Tailwind CSS + Eslint + Prettier.
-- [vite-react-ts-tailwind-template](https://github.com/nrabhiram/vite-react-ts-tailwind-template) - React | TypeScript | ESLint | Prettier | Husky | Vitest for specs | Tailwind + CSS Modules
+- [vite-react-ts-tailwind-template](https://github.com/nrabhiram/vite-react-ts-tailwind-template) - React, TypeScript, ESLint, Prettier, Husky, Vitest for specs, and Tailwind + CSS Modules.
 
 #### Svelte
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-mui-ts](https://github.com/emre-cil/vite-mui-ts) - React + TypeScript + Redux + Material UI + RRD + ESLint + Prettier.
 - [leo-react-app](https://github.com/Leo-Henrique/leo-react-app) - React + SASS | Template for React applications with SASS boilerplate for consistent interfaces.
 - [template-vite-react-ts-tailwind](https://github.com/RoyRao2333/template-vite-react-ts-tailwind) - React + TypeScript + Tailwind CSS + Eslint + Prettier.
+- [vite-react-ts-tailwind-template](https://github.com/nrabhiram/vite-react-ts-tailwind-template) - React | TypeScript | ESLint | Prettier | Husky | Vitest for specs | Tailwind + CSS Modules
 
 #### Svelte
 


### PR DESCRIPTION
This PR adds a starter template for React with TypeScript and Tailwind CSS, using Vite.

## Motivation

This template is configured with tools (along with Vite) to enhance the development experience when working on a React application.

1. ESLint + Prettier → enforce code styles and format the code
2. Vitest → write specs for the application
3. Husky → ensures that the build is green, i.e. all of the specs pass, before making a commit
4. Tailwind + CSS Module → write scoped styles for your components with Tailwind's utility classes

### Why Use Tailwind With CSS Modules?

Tailwind provides utility classes for patterns that are commonly repeated when writing CSS code. With the help of CSS modules, you can use these utility classes to create scoped styles while writing minimal CSS code.

## Checklist

- [x] Title as described.
- [x] Make sure you put things in the right category.
- [x] The description of your item should be a sentence with less than 24 words.
- [x] Avoid using links and parentheses in description. 
- [x] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [x] Use proper case for terms (e.g. `GitHub`, `TypeScript`, `ESLint`, etc.)
- [x] When mentioning tools, omit versions whenever possible (e.g. use `TypeScript` instead of `TypeScript 4.x`, but keep `Vue 2` and `Vue 3` as they're incompatible).
- [x] When mentioning package names, use quotes whenever possible.
- [x] Always add your items to the end of a list.

### Starter Templates

- [x] The starter template is working with **Vite 2.x and onward**.
- [x] The documentation is in English.
- [x] The starter template must provide enough instructions / documentation about how to start up and what's included.
- [x] A screenshot or a live demo should be included.
- [ ] The repo should be at least 30 days old.
- [x] Should be differentiable from the existing starter templates. 
