### PR TITLE
Add two Solid plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,8 +533,8 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 #### Integrations
 
 - [vite-plugin-solid](https://github.com/amoutonbrady/vite-plugin-solid) - Provides JSX transformation for Solid.
-- [vite-plugin-solid-markdown](https://github.com/xbmlz/vite-plugin-solid-markdown) - A vite plugin for compiling markdown files to solid components.
-- [vite-plugin-solid-svg](https://github.com/jfgodoy/vite-plugin-solid-svg) - Vite plugin to Import SVG files as Solid.js Components
+- [vite-plugin-solid-markdown](https://github.com/xbmlz/vite-plugin-solid-markdown) - Compile markdown files to Solid components.
+- [vite-plugin-solid-svg](https://github.com/jfgodoy/vite-plugin-solid-svg) - Import SVG files as Solid.js Components.
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,6 @@ Use the "Table of Contents" menu on the top-left corner to explore the list.
 - [vite-plugin-virtual-mpa](https://github.com/emosheeep/vite-plugin-virtual-mpa) - Out-of-box MPA plugin, with html template engine and virtual files support, which generate multiple files using only one template.
 - [tailwindcss-vite-plugin](https://github.com/await-ovo/tailwindcss-webpack-plugin) - Tailwind CSS integration.
 - [vite-plugin-assemblyscript-asc](https://github.com/krymel/vite-plugin-assemblyscript-asc) - AssemblyScript integration with full support for HMR, ESM import bindings, and source maps.
-- [vite-plugin-solid-markdown](https://github.com/xbmlz/vite-plugin-solid-markdown) - A vite plugin for compiling markdown files to solid components.
 - [vite-plugin-qiniu-oss](https://github.com/th-come/vite-plugin-qiniu-oss) - Upload the production files bundled in the project to qiniu OSS, except for HTML.
 - [vite-plugin-stylelint](https://github.com/ModyQyW/vite-plugin-stylelint) - Runs Stylelint synchronously/asynchronously.
 - [Vite-plugin-graphiql](https://github.com/mammadataei/vite-plugin-graphiql) - Integrattion for GraphiQL IDE.
@@ -534,6 +533,8 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 #### Integrations
 
 - [vite-plugin-solid](https://github.com/amoutonbrady/vite-plugin-solid) - Provides JSX transformation for Solid.
+- [vite-plugin-solid-markdown](https://github.com/xbmlz/vite-plugin-solid-markdown) - A vite plugin for compiling markdown files to solid components.
+- [vite-plugin-solid-svg](https://github.com/jfgodoy/vite-plugin-solid-svg) - Vite plugin to Import SVG files as Solid.js Components
 
 <hr>
 


### PR DESCRIPTION
- [`vite-plugin-solid-markdown`](https://github.com/xbmlz/vite-plugin-solid-markdown) was already listed, but miscategorized under the "framework-agnostic plugins" section
- [`vite-plugin-solid-svg`](https://github.com/jfgodoy/vite-plugin-solid-svg) is new ✨ 

Both added underneath the SolidJS plugins section.

---

## Checklist

- [X] Title as described.
- [X] Make sure you put things in the right category.
- [X] The description of your item should be a sentence with less than 24 words.
- [X] Avoid using links and parentheses in description. 
- [X] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [X] Use proper case for terms (e.g. `GitHub`, `TypeScript`, `ESLint`, etc.)
- [X] When mentioning tools, omit versions whenever possible (e.g. use `TypeScript` instead of `TypeScript 4.x`, but keep `Vue 2` and `Vue 3` as they're incompatible).
- [X] When mentioning package names, use quotes whenever possible.
- [X] Always add your items to the end of a list.

### Plugins/Tools

- [X] The plugin/tool is working with **Vite 2.x and onward**.
- [X] The project is Open Source.
- [X] The project follows the [Vite Plugins Conventions](https://vitejs.dev/guide/api-plugin.html#conventions).
- [X] The plugin uses Vite-specific hooks and can't be implemented as a [Compatible Rollup Plugin](https://vitejs.dev/guide/api-plugin.html#rollup-plugin-compatibility).
- [X] The repo should be at least 30 days old.
- [X] The documentation is in English.
- [X] The project is active and maintained (inactive projects for longer 6 months will be removed without further notice).
- [X] The project accepts contributions.
- [X] Not a commercial product.