### PR TITLE
docs: update @nxext/angular-vite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 
 #### Integrations
 
-- [@nxext/angular-vite](https://github.com/nxext/nx-extensions/tree/main/packages/angular/vite) - A plugin that uses SWC to compile Angular modules.
+- [@nxext/angular-vite](https://github.com/nxext/nxext-experimental/tree/main/packages/angular/vite) - A plugin that uses SWC to compile Angular modules.
 
 <hr>
 


### PR DESCRIPTION
> Please make sure all the requirements are satisfied, otherwise the PR could be closed without further notice.

The '@nxext/angular-vite' plugin link is broken because this plugin has moved to an experimental repo.
Fix https://github.com/vitejs/awesome-vite/issues/711

## Checklist

- [X] Title as described.
- [X] Make sure you put things in the right category.
- [X] The description of your item should be a sentence with less than 24 words.
- [X] Avoid using links and parentheses in description. 
- [X] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [X] Use proper case for terms (e.g. `GitHub`, `TypeScript`, `ESLint`, etc.)
- [X] When mentioning tools, omit versions whenever possible (e.g. use `TypeScript` instead of `TypeScript 4.x`, but keep `Vue 2` and `Vue 3` as they're incompatible).
- [X] When mentioning package names, use quotes whenever possible.

