### PR TITLE
Add new template "vite-react-component-library-starter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [vite-react-flow-template](https://github.com/xyflow/vite-react-flow-template) - React Flow starter template.
 - [react-vite-template](https://github.com/Mirazex/react-vite-template) - React, TypeScript, Vite, Mantine, Million, Husky, Prettier, Import Sorter, Lint-staged.
 - [gravity-ui-vite-template](https://github.com/gravity-ui/gravity-ui-vite-example) - Template with Gravity UI ecosystem (React, TypeScript, Gravity UI, Vite, Husky, ESLint, Prettier, Lint-staged).
+- [vite-react-component-library-starter](https://github.com/rayyamhk/vite-react-component-library-starter) - A starter template for creating React component libraries with TypeScript, Tailwind CSS, Storybook, Vitest, ESLint, Prettier, Husky, and GitHub Action.
 
 #### Svelte
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [vite-react-flow-template](https://github.com/xyflow/vite-react-flow-template) - React Flow starter template.
 - [react-vite-template](https://github.com/Mirazex/react-vite-template) - React, TypeScript, Vite, Mantine, Million, Husky, Prettier, Import Sorter, Lint-staged.
 - [gravity-ui-vite-template](https://github.com/gravity-ui/gravity-ui-vite-example) - Template with Gravity UI ecosystem (React, TypeScript, Gravity UI, Vite, Husky, ESLint, Prettier, Lint-staged).
-- [vite-react-component-library-starter](https://github.com/rayyamhk/vite-react-component-library-starter) - A starter template for creating React component libraries with TypeScript, Tailwind CSS, Storybook, Vitest, ESLint, Prettier, Husky, and GitHub Action.
+- [vite-react-component-library-starter](https://github.com/rayyamhk/vite-react-component-library-starter) - A starter template for creating React component libraries with `TypeScript`, `Tailwind CSS`, `Storybook`, `Vitest`, `ESLint`, `Prettier`, `Husky`, and `GitHub Action`.
 
 #### Svelte
 


### PR DESCRIPTION
[vite-react-component-library-starter](https://github.com/rayyamhk/vite-react-component-library-starter) is a starter template for creating React component libraries using Vite. It includes a robust set of features to help you develop, test, and build your library efficiently.

## Checklist

- [x] Title as described.
- [x] Make sure you put things in the right category.
- [x] The description of your item should be a sentence with less than 24 words.
- [x] Avoid using links and parentheses in description. 
- [x] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [x] Use proper case for terms (e.g. `GitHub`, `TypeScript`, `ESLint`, etc.)
- [x] When mentioning tools, omit versions whenever possible (e.g. use `TypeScript` instead of `TypeScript 4.x`, but keep `Vue 2` and `Vue 3` as they're incompatible).
- [x] When mentioning package names, use quotes whenever possible.
- [x] Always add your items to the end of a list.

### Starter Templates

<!-- Ignore if you are not contributing to Starter Templates -->

- [x] The starter template is working with **Vite 2.x and onward**.
- [x] The documentation is in English.
- [x] The starter template must provide enough instructions / documentation about how to start up and what's included.
- [x] A screenshot or a live demo should be included.
- [x] Should be differentiable from the existing starter templates. 
