### PR TITLE
Remove: vite-plugin-eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,6 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [vite-plugin-mpa](https://github.com/IndexXuan/vite-plugin-mpa) - Out-of-box multi-page application (MPA) integration.
 - [vite-plugin-linter](https://bitbucket.org/unimorphic/vite-plugin-linter) - Extensible linter framework that shows the linting output in the Vite output and the browser console, includes ESLint & TypeScript ootb.
 - [vite-plugin-checker](https://github.com/fi3ework/vite-plugin-checker) - Fast run checkers (TypeScript/VLS/vue-tsc, etc.) in worker threads with overlay and terminal hint.
-- [@nabla/vite-plugin-eslint](https://github.com/nabla/vite-plugin-eslint) - Runs ESLint asynchronously in a worker to keep HMR fast.
 - [vite-plugin-tauri](https://github.com/amrbashir/vite-plugin-tauri) - Integrate Tauri in a Vite project to build cross-platform apps.
 - [vite-plugin-federation](https://github.com/originjs/vite-plugin-federation) - Support Module Federation, Inspired by Webpack Module Federation feature.
 - [vite-plugin-wasm-pack](https://github.com/nshen/vite-plugin-wasm-pack) - Integration with rust [wasm-pack](https://github.com/rustwasm/wasm-pack), the simple way.


### PR DESCRIPTION
Removes vite-plugin-eslint which is _**majorly broken**_ and seemingly long abandoned- unmaintained with _no pull-requests merged or commits added in the last year_. (No notes from @gxmari007 in repo readme about project status ¯\\\_(ツ)_/¯ )

https://github.com/gxmari007/vite-plugin-eslint/issues/83