### PR TITLE
docs: Add the @yoichiro/vite-plugin-handlebars plugin to the Transformers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [vite-plugin-icons-spritesheet](https://github.com/forge42dev/vite-plugin-icons-spritesheet) - Generate a spritesheet and TypeScript types from SVG icons by listening to the icons folder changes.
 - [vite-plugin-abbrlink](https://github.com/tangerball/abbrlink/tree/master/packages/vite-plugin-abbrlink#readme) - Add the abbrlink attribute to the `markdown` file in the specified directory.
 - [vite-plugin-native](https://github.com/vite-plugin/vite-plugin-native) - Supports Node/Electron C/C++ native addons.
+- [@yoichiro/vite-plugin-handlebars](https://github.com/yoichiro/vite-plugin-handlebars) - Enables the easy import of Handlebars templates `.hbs` as ES Modules within Vite projects.
 
 #### Helpers
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [vite-plugin-icons-spritesheet](https://github.com/forge42dev/vite-plugin-icons-spritesheet) - Generate a spritesheet and TypeScript types from SVG icons by listening to the icons folder changes.
 - [vite-plugin-abbrlink](https://github.com/tangerball/abbrlink/tree/master/packages/vite-plugin-abbrlink#readme) - Add the abbrlink attribute to the `markdown` file in the specified directory.
 - [vite-plugin-native](https://github.com/vite-plugin/vite-plugin-native) - Supports Node/Electron C/C++ native addons.
-- [@yoichiro/vite-plugin-handlebars](https://github.com/yoichiro/vite-plugin-handlebars) - Enables the easy import of Handlebars templates `.hbs` as ES Modules within Vite projects.
+- [@yoichiro/vite-plugin-handlebars](https://github.com/yoichiro/vite-plugin-handlebars) - Import of Handlebars templates `.hbs` as ES Modules.
 
 #### Helpers
 


### PR DESCRIPTION
## Checklist

- [x] Title as described.
- [x] Make sure you put things in the right category.
- [x] The description of your item should be a sentence with less than 24 words.
- [x] Avoid using links and parentheses in description. 
- [x] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [x] Use proper case for terms (e.g. `GitHub`, `TypeScript`, `ESLint`, etc.)
- [x] When mentioning tools, omit versions whenever possible (e.g. use `TypeScript` instead of `TypeScript 4.x`, but keep `Vue 2` and `Vue 3` as they're incompatible).
- [x] When mentioning package names, use quotes whenever possible.
- [x] Always add your items to the end of a list.

### Plugins/Tools

- [x] The plugin/tool is working with **Vite 2.x and onward**.
- [x] The project is Open Source.
- [x] The project follows the [Vite Plugins Conventions](https://vitejs.dev/guide/api-plugin.html#conventions).
- [x] The plugin uses Vite-specific hooks and can't be implemented as a [Compatible Rollup Plugin](https://vitejs.dev/guide/api-plugin.html#rollup-plugin-compatibility).
- [x] The repo should be at least 30 days old.
- [x] The documentation is in English.
- [x] The project is active and maintained (inactive projects for longer 6 months will be removed without further notice).
- [x] The project accepts contributions.
- [x] Not a commercial product.
