### PR TITLE
Add vite-react-searchcraft-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [celeris-web](https://github.com/kirklin/celeris-web) - Template based on `Vite` + `Vue3` + `TypeScript` + `Vue-Router` + `Pinia` + `Unocss` + `Naive UI` + `pnpm Monorepo`.
 - [vite-ts-starter](https://github.com/pdsuwwz/vite-ts-starter) - Vue `I18n` Dynamic Router Localization Template, Internationalized Applications with `UnoCSS` + `Unplugin` + `Element-Plus` + `Vitest` + `TypeScript` + `Vue-Router` + `Vuex` + `Scss` + `ESLint` + `Stylelint` + `Husky` + `lint-staged`.
 - [vite-vue3-tailwind4-daisyui5-starter-template](https://github.com/martinille/starter-template-vite-vue3-sass-tailwind4-daisyui5) - Starter template with Vue 3 + Vite + Tailwind CSS 4 + DaisyUI 5 + Sass.
+- [vite-vue-searchcraft-template](https://github.com/searchcraft-inc/vite-vue-searchcraft-template) - A `Vue` + `TypeScript` starter template for building apps with Searchcraft.
 
 #### Vue 2
 


### PR DESCRIPTION
## Checklist

- [x] Title as described.
- [x] Make sure you put things in the right category.
- [x] The description of your item should be a sentence with less than 24 words.
- [x] Avoid using links and parentheses in description. 
- [x] Omit unnecessary words already provided in the context (e.g. `for Vite`, `a Vite plugin`).
- [x] Use proper case for terms (e.g. `GitHub`, `TypeScript`, `ESLint`, etc.)
- [x] When mentioning tools, omit versions whenever possible (e.g. use `TypeScript` instead of `TypeScript 4.x`, but keep `Vue 2` and `Vue 3` as they're incompatible).
- [x] When mentioning package names, use quotes whenever possible.
- [x] Always add your items to the end of a list.

### Starter Templates

- [x] The starter template is working with **Vite 2.x and onward**.
- [x] The documentation is in English.
- [x] The starter template must provide enough instructions / documentation about how to start up and what's included.
- [x] A screenshot or a live demo should be included.
- [x] The repo should be at least 30 days old.
- [x] Should be differentiable from the existing starter templates. 

Searchcraft is a developer-friendly search platform that lets you quickly add fast, typo-tolerant, and customizable search to your front-end applications without needing to manage backend infrastructure.

This PR adds a link to [vite-react-searchcraft-template](https://github.com/searchcraft-inc/vite-react-searchcraft-template), which is a `React` + `TypeScript` starter template for building apps with Searchcraft. This template makes it super easy to spin up a new Vite app and get up and running with Searchcraft in minutes.

For a demonstration of this template in action, our CTO shows that it's even possible to use it [while eating some of the spiciest ramen noodles in the world](https://www.youtube.com/watch?v=zo-YBOEGi2s).



