### PR TITLE
Add vite-plugin-image-tools to Bundling plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [vite-plugin-cp](https://github.com/fengxinming/vite-plugins/tree/main/packages/vite-plugin-cp) - Copy files after building bundles.
 - [unplugin-imagemin](https://github.com/ErKeLost/unplugin-imagemin) - High performance compressed Picture based on squoosh and sharp.
 - [vite-plugin-image-optimizer](https://github.com/FatehAK/vite-plugin-image-optimizer) - Optimize (compress) your image assets using Sharp.js and SVGO at build time.
+- [vite-plugin-image-tools](https://github.com/illusionGD/vite-plugin-image-tools) - Image compression, WebP conversion, and sprite sheet generation.
 - [vite-plugin-no-bundle](https://github.com/ManBearTM/vite-plugin-no-bundle) - Generate unbundled code for use with native ESM or other bundlers.
 - [vite-plugin-css-injected-by-js](https://github.com/marco-prontera/vite-plugin-css-injected-by-js) - Takes the CSS and adds it to the page through the JS.
 - [unplugin-zip-pack](https://github.com/iamspark1e/unplugin-zip-pack) - Zip your dist with filter function support.


### PR DESCRIPTION
Add `vite-plugin-image-tools` plugin to the Bundling section. This plugin provides image compression, WebP conversion, and sprite sheet generation capabilities for Vite projects.

**Plugin URL:** https://github.com/illusionGD/vite-plugin-image-tools

> Please make sure all the requirements are satisfied, otherwise the PR could be closed without further notice.

## Checklist

- [x] Title as described.
- [x] Make sure you put things in the right category.
- [x] The description of your item is a sentence with less than 24 words.
- [x] Avoid using links and parentheses in description.
- [x] Omit unnecessary words already provided in the context.
- [x] Use proper case for terms.
- [x] Omit versions when mentioning tools unless necessary.
- [x] Use quotes when mentioning package names.
- [x] Added the item to the end of the list.

### Plugins / Tools

- [x] The plugin works with **Vite 2.x and onward**.
- [x] The project is Open Source.
- [x] The project follows the Vite Plugins Conventions.
- [x] The plugin uses Vite-specific hooks and cannot be implemented as a compatible Rollup plugin.
- [x] The repository is at least 30 days old.
- [x] The documentation is in English.
- [x] The project is active and maintained.
- [x] The project accepts contributions.
- [x] The plugin is not a commercial product.

### Starter Templates

- [x] Not applicable.

### Apps / Websites

- [x] Not applicable.

