### PR TITLE
Add Veritas Kanban to Open Source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,6 +834,7 @@ In this section, we use badges to indicate the targeted Vue version for each plu
 - [@lazarv/react-server](https://github.com/lazarv/react-server) - A React meta-framework.
 - [WXT](https://github.com/wxt-dev/wxt) - Framework for building web extensions, with the same DX as Nuxt.
 - [Revili](https://github.com/revilijs/revili) - A command and GUI integration tool.
+- [Veritas Kanban](https://github.com/BradGroux/veritas-kanban) - Self-hosted Kanban board with AI agent integration, built with React 19, Vite 6, and TanStack Query.
 
 ### Apps/Websites
 


### PR DESCRIPTION
Adds [Veritas Kanban](https://github.com/BradGroux/veritas-kanban) to the Open Source section under Projects Using Vite.js.

Self-hosted Kanban board with AI agent integration, built with:
- **Vite 6** with vendor chunk splitting (69% bundle reduction)
- React 19, TypeScript strict mode
- TanStack Query with WebSocket-aware polling
- dnd-kit, Shadcn UI, Recharts
- 1,255 tests (Vitest + Playwright E2E)

67+ stars, currently trending on r/reactjs.