### PR TITLE
Add resource-fallback — zero-intrusion asset fallback plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [vite-plugin-year](https://github.com/8hobbies/vite-plugin-year) - Inserts the current year to the HTML file during build. Useful for adding a copyright year to the HTML file.
 - [vite-plugin-llms](https://github.com/saschaseniuk/vite-plugin-llms) - Integration for the llms.txt specification supporting AI optimized content alongside application routes.
 - [`module-federation/vite`](https://github.com/module-federation/vite) - Official Module Federation integration, enabling dynamic remote module loading.
+- [resource-fallback](https://github.com/ben-lau/resource-fallback) - Runtime retry, multi-CDN fallback, and origin recovery for Vite build assets (JS/CSS chunks, dynamic import) — zero business code changes.
 
 #### Loaders
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [vite-plugin-year](https://github.com/8hobbies/vite-plugin-year) - Inserts the current year to the HTML file during build. Useful for adding a copyright year to the HTML file.
 - [vite-plugin-llms](https://github.com/saschaseniuk/vite-plugin-llms) - Integration for the llms.txt specification supporting AI optimized content alongside application routes.
 - [`module-federation/vite`](https://github.com/module-federation/vite) - Official Module Federation integration, enabling dynamic remote module loading.
-- [resource-fallback](https://github.com/ben-lau/resource-fallback) - Runtime retry, multi-CDN fallback, and origin recovery for Vite build assets (JS/CSS chunks, dynamic import) — zero business code changes.
+- [@resource-fallback/vite-plugin](https://github.com/ben-lau/resource-fallback/tree/main/packages/vite-plugin) - Runtime retry, multi-CDN fallback, and origin recovery for Vite build assets (JS/CSS chunks, dynamic import) — zero business code changes.
 
 #### Loaders
 


### PR DESCRIPTION
## Summary

Adds [resource-fallback](https://github.com/ben-lau/resource-fallback) — a runtime resource fallback solution for frontend build outputs (Vite & Webpack).

## What it does

When a CDN or static asset URL fails at runtime, resource-fallback automatically:

**retry → switch to backup CDN → fall back to origin**

…without requiring changes to application code. Works with sync/async JS, CSS chunks, `React.lazy`, Vue `defineAsyncComponent`, Vue Router lazy routes, and more.

## Why it fits this list

- **Vite 4+** plugin: [`@resource-fallback/vite-plugin`](https://www.npmjs.com/package/@resource-fallback/vite-plugin)
- **Webpack 5+** plugin: [`@resource-fallback/webpack-plugin`](https://www.npmjs.com/package/@resource-fallback/webpack-plugin)
- Shared browser runtime: [`@resource-fallback/core`](https://www.npmjs.com/package/@resource-fallback/core)
- MIT licensed, actively maintained, with CI, tests, and docs

## How it differs from similar tools

This is **not** a build-time CDN import plugin (e.g. swapping React/Vue to a CDN at compile time).

It targets a different problem: **your own build artifacts** (entry bundles, async chunks, CSS) failing to load in the browser due to CDN/network issues — with a unified retry + multi-source fallback strategy.

Compared to Webpack-only retry plugins, it also covers **Vite**, DOM `<script>`/`<link>` error handling, optional **Hybrid Service Worker** for images/fonts/CSS `url()`, per-host **circuit breaker**, kill switches, and CSP/SRI compatibility.

## Links

- Repo: https://github.com/ben-lau/resource-fallback
- Docs: https://ben-lau.github.io/resource-fallback/en/
- npm (core): https://www.npmjs.com/package/@resource-fallback/core
- npm (vite-plugin): https://www.npmjs.com/package/@resource-fallback/vite-plugin
- npm (webpack-plugin): https://www.npmjs.com/package/@resource-fallback/webpack-plugin

## README change

See diff — one line under **[CATEGORY]**.