### PR TITLE
Add Taro with `vite-plugin-taro`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [bati](https://github.com/batijs/bati) - Scaffolding a Vike project.
 - [create-awesome-node-app](https://github.com/Create-Node-App/create-node-app) - Scaffolding your project choosing between different templates.
 - [create-nitro-app](https://github.com/nitrojs/create-nitro-app) - Scaffolding your Full-Stack Vite project using Nitro.
+- [create-vite-taro](https://github.com/sep2/vite-plugin-taro/tree/main/packages/create-vite-taro) - Scaffolding a Taro 4 + React 19 + Vite 8 Project.
 
 ### Templates
 
@@ -203,9 +204,14 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [vite-electron-plugin](https://github.com/electron-vite/vite-electron-plugin) - High-performance, esbuild-based Vite Electron plugin.
 - [vite-plugin-doubleshot](https://github.com/Doubleshotjs/doubleshot/tree/main/packages/plugin-vite) - For building Node.js backend or Electron main process.
 
+
 ### Tauri
 
 - [HuLa](https://github.com/HuLaSpark/HuLa) - is a desktop instant messaging app built on `Vite 5` + `Vue 3` + `TypeScript` + `Tauri` (not just instant messaging).
+
+### Taro
+
+- [Taro](https://github.com/sep2/vite-plugin-taro) - Build WeChat Mini Apps with the latest standard frontend stack: Vite 8, Taro 4, React 19, and Tailwind CSS v4.
 
 #### Neutralino
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 - [bati](https://github.com/batijs/bati) - Scaffolding a Vike project.
 - [create-awesome-node-app](https://github.com/Create-Node-App/create-node-app) - Scaffolding your project choosing between different templates.
 - [create-nitro-app](https://github.com/nitrojs/create-nitro-app) - Scaffolding your Full-Stack Vite project using Nitro.
-- [create-vite-taro](https://github.com/sep2/vite-plugin-taro/tree/main/packages/create-vite-taro) - Scaffolding a Taro 4 + React 19 + Vite 8 Project.
+- [create-vite-taro](https://github.com/sep2/vite-plugin-taro/tree/main/packages/create-vite-taro) - Scaffolding a Taro + React + Vite Project.
 
 ### Templates
 
@@ -211,7 +211,7 @@ Use the "Table of Contents" menu on the top-right corner to explore the list.
 
 ### Taro
 
-- [Taro](https://github.com/sep2/vite-plugin-taro) - Build WeChat Mini Apps with the latest standard frontend stack: Vite 8, Taro 4, React 19, and Tailwind CSS v4.
+- [Taro](https://github.com/sep2/vite-plugin-taro) - Build WeChat Mini Apps with the latest standard frontend stack: Vite + Taro + React + Tailwind CSS.
 
 #### Neutralino
 


### PR DESCRIPTION
Build WeChat Mini Apps with the latest standards-based frontend stack: Vite, React, and Tailwind CSS.

`vite-plugin-taro` is for applications that want Taro's cross-platform React components and APIs, but prefer Vite instead of Taro webpack. You only need this plugin to build a complete WeChat Mini Program.

Live demo: <https://sep2.github.io/vite-plugin-taro>. See [Sample app](https://github.com/sep2/vite-plugin-taro/tree/main/packages/loan-genius/README.en.md) how to run it locally.

- **Native Vite builds** Use standard Vite 8 config instead of legacy webpack configuration, with support for all Vite plugins.
- **Hot reload** Both WeChat Mini Program and H5 support dev-mode watch, with Vite 8 HMR/rebuilds for fast feedback.
- **Battle-tested Taro foundation** Use the full set of Taro APIs and components instead of reinventing cross-platform primitives.
- **Tailwind ready** Built-in Tailwind CSS v4 support for both WeChat Mini Program and H5 styles.
- **Conditional compilation** Use Taro-style `#ifdef` / `#ifndef` / `#if` blocks to split code and styles by WeChat / web target.
- **Workspace friendly** Supports standalone apps and monorepos, with npm, pnpm, Yarn, Bun, and other package managers.
- **Type-friendly** The project supports TypeScript all the way.
- **WeChat Skyline** Support WeChat Mini Program output with Skyline rendering mode.